### PR TITLE
Update resume content for 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,54 @@ To invoke the API gateway endpoint manually using the curl command:
     Content           : {"visitor_count": 3}
 ```
 
-## Builds Provisioning:
-This project makes use of github action workflow to automatically provision all the resources for the website on AWS
-on a code change to the default branch on this repo.  
-AWS access for the github action builds are controlled through the use of IAM roles instead of security credentials per  
-security best practices.
+## Deploying a content change to the live site
+
+This is what I do when I need to update the resume content at [https://www.ikkidev.com](https://www.ikkidev.com):
+
+1. Make the HTML change on a feature branch off `main`:
+   ```bash
+   git checkout main && git pull
+   git checkout -b resume-update-<date>
+   # edit Webpage/src/index.html
+   git commit -am "Update resume content"
+   git push -u origin resume-update-<date>
+   ```
+2. Open a PR and merge it into `main`. The merge push to `main` triggers [`.github/workflows/main.yml`](.github/workflows/main.yml), which runs the Lambda tests and `terraform apply` against the prod env.
+3. The S3 module uses `aws_s3_object` with `filemd5` for every file under `Webpage/src/`, so any changed file gets re-uploaded on the next apply. No separate sync step.
+4. **Invalidate the CloudFront cache.** Terraform does not do this for me, and the CDN will keep serving the old HTML until I tell it not to:
+   ```bash
+   awsume <prod-profile>
+   aws cloudfront create-invalidation \
+     --distribution-id <DIST_ID> \
+     --paths "/" "/index.html"
+   ```
+   To find the distribution ID:
+   ```bash
+   # Option A: from terraform output, run from terraform-cloud-resume/
+   terraform output
+
+   # Option B: list distributions filtered by the ikkidev.com alias
+   aws cloudfront list-distributions \
+     --query "DistributionList.Items[?Aliases.Items[?contains(@, 'ikkidev.com')]].{Id:Id,Aliases:Aliases.Items}" \
+     --output table
+   ```
+   There are two distributions (one for `www`, one for the apex redirect). The `www` one is the one to invalidate.
+
+## CI auth (OIDC)
+
+The workflow does not use long-lived AWS keys. It uses GitHub OIDC and assumes
+`arn:aws:iam::521555160642:role/github-actions-role` in `ca-central-1`.
+
+The trust policy on that role conditions on the GitHub token's `sub` claim, which looks like:
+```
+repo:ikkidev/CloudResume:ref:refs/heads/<branch>
+```
+
+**Important.** If I rename the default branch or rotate the role, the trust policy condition has to match the branch the workflow runs on. The repo's default branch is `main`, so the condition needs to be:
+```json
+"token.actions.githubusercontent.com:sub": "repo:ikkidev/CloudResume:ref:refs/heads/main"
+```
+If this drifts (e.g. stuck on `master` after a branch rename), the workflow fails at the "Configure aws credentials" step with an AssumeRole error and nothing deploys.
+
+The workflow itself needs `permissions: id-token: write` so GitHub can mint the OIDC token. That block is already in `main.yml`.
 

--- a/Webpage/src/index.html
+++ b/Webpage/src/index.html
@@ -17,8 +17,8 @@
         <div class="row">
             <div class="col-md">
                 <h1>Ikki Lachance</h1>
-                <h5>Senior Software Engineer | Platform Runtime &amp; SDKs | Distributed Systems</h5>
-                <p class="border-top pt-3">Platform engineer with 10+ years building distributed systems from the ground up across SDK design, API infrastructure, CI/CD, and reliability engineering. Joined Intelerad when existing automation could not support the scale the company needed and built a foundation that has since scaled to 800+ global sites. Reduces toil and raises the engineering floor by designing cross-cutting developer tools, messaging systems, and caching layers across large service fleets.</p>
+                <h5>Staff Software Engineer | Platform Engineering | Healthcare Systems</h5>
+                <p class="border-top pt-3">Staff software engineer, 10+ years in healthcare and finance. Built the CI/CD and AWS foundation at Intelerad that now runs 800+ global healthcare sites, starting from a fully on-prem platform with no automation in place. Earlier, designed Morgan Stanley's OTC Derivatives reporting platform from scratch. The work I'm most proud of is the cross-cutting kind. Architecture decisions, cross-team coordination, and mentoring engineers through the harder parts.</p>
             </div>
         </div>
     </div>
@@ -65,22 +65,12 @@
                 </ul>
             </div>
             <div class="row">
-                <h2 class="mb-5">Certification</h2>
-                <ul class="no-bullet mb-5">
-                    <li>
-                        <h6 class="text-primary">AWS Certified Solutions Architect - Associate</h6>
-                    </li>
-                    <li class="text-secondary"> Amazon Web Services</li>
-                    <li> Issued Feb. 2020 - Expires Feb. 2023</li>
-                </ul>
-            </div>
-            <div class="row">
                 <h2 class="mb-5">Skills</h2>
                 <ul class="no-bullet mb-5">
-                    <li class="mb-3"><strong>SDK and Platform</strong><br>SDK design, runtime environments, shared libraries, developer tooling, REST API design, Go, Python 3, Bash, SQL</li>
-                    <li class="mb-3"><strong>Cloud and Infrastructure</strong><br>AWS (ECS, EKS, RDS, SSM, IAM, CloudWatch, KMS), Terraform, HashiCorp Vault</li>
-                    <li class="mb-3"><strong>Messaging and Caching</strong><br>Messaging architectures, distributed caching, configuration management, service connectivity</li>
-                    <li class="mb-3"><strong>Platform and Delivery</strong><br>Kubernetes, Docker, Jenkins, Ansible, AWX, CI/CD pipeline design, microservices architecture</li>
+                    <li class="mb-3"><strong>Cloud and Infrastructure</strong><br>AWS (ECS, EFS, ECR, RDS PostgreSQL, SSM, IAM, CloudWatch, KMS), Terraform, HashiCorp Vault, OpenVPN</li>
+                    <li class="mb-3"><strong>Automation and CI/CD</strong><br>Ansible, AWX, Jenkins, Docker, Kubernetes (EKS)</li>
+                    <li class="mb-3"><strong>Languages</strong><br>Python 3, Go, Bash, SQL</li>
+                    <li class="mb-3"><strong>Databases and Messaging</strong><br>PostgreSQL, MongoDB, event-driven messaging architectures</li>
                     <li class="mb-3"><strong>Security and Compliance</strong><br>PKI/TLS, KMS encryption, SSM Patch Manager, CVE remediation, HIPAA-adjacent system design</li>
                 </ul>
             </div>
@@ -91,32 +81,33 @@
 
                 <h6 class="text-primary">Tech Lead, Platform Services | Intelerad | Aug 2024 - Present | New York, NY</h6>
                 <ul>
-                    <li>Redesigned a client connectivity platform on AWS ECS, replacing a brittle on-premises VPN fleet with a self-healing architecture that achieved 99.9% uptime across 800+ global healthcare sites.</li>
-                    <li>Designed a connectivity metadata API exposing client server compatibility and connection health across 800+ sites, giving internal teams early signal on degradation before it impacted service availability.</li>
-                    <li>Led a Python 2 to Python 3 migration across all platform services, unblocking automated CVE scanning and OS patch management fleet-wide and closing a long-standing security compliance gap.</li>
-                    <li>Led two cross-functional teams of 8 engineers, introduced architecture reviews for greenfield projects, and established information-sharing practices that eliminated knowledge silos across both teams.</li>
+                    <li>Rebuilt the client connectivity platform on AWS ECS, taking 800+ healthcare sites from a flaky on-prem VPN fleet to 99.9% network uptime.</li>
+                    <li>Drove the Python 2 to Python 3 migration to completion across all platform services, unblocking automated CVE scanning and OS patch management fleet-wide.</li>
+                    <li>Own architecture decisions across multi-quarter initiatives, breaking roadmap work into trackable epics and clearing cross-team blockers with SRE, QA, and product.</li>
+                    <li>Mentor engineers through architecture reviews, pair programming, and onboarding, raising the team's autonomy so day-to-day decisions no longer route through senior engineers by default.</li>
                 </ul>
 
                 <h6 class="text-primary">Senior Software Engineer, SRE | Intelerad | Jan 2021 - Aug 2024 | Montreal, QC</h6>
                 <ul>
-                    <li>Built LCM Precheck 2.0, a REST API-backed validation platform automating pre-deployment readiness checks across configuration, connectivity, and service dependencies, raising first-attempt success from 50% to 80%.</li>
-                    <li>Designed and led the core platform migration from on-premises to AWS ECS with Terraform and PostgreSQL, cutting software release operations from multi-day per-site work to hours across 10,000+ servers.</li>
-                    <li>Migrated an Ansible-based automation platform to Kubernetes on EKS, enabling job workers to scale on demand across the full client fleet and eliminating capacity ceilings on automated operations.</li>
-                    <li>Implemented TLS across an internal messaging bus and centralized credential management with HashiCorp Vault and AWS SSM, eliminating an unencrypted data path in a HIPAA-adjacent environment.</li>
+                    <li>Led the core platform migration from on-prem to AWS ECS with Terraform and PostgreSQL, cutting release operations from multi-day per-site work to hours across 800+ clients and 10,000+ servers.</li>
+                    <li>Built LCM Precheck 2.0, a REST API that catches connectivity and service dependency failures a week before maintenance windows, raising first-attempt deployment success from 50% to 80% across 800+ sites.</li>
+                    <li>Migrated the Ansible automation platform to Kubernetes on AWS so job workers scale on demand and concurrent deployments are no longer bottlenecked.</li>
+                    <li>Centralized secrets management with HashiCorp Vault and AWS SSM and rolled out TLS on the internal messaging bus, removing ad-hoc credential sharing and the unencrypted data path in our HIPAA-adjacent environment.</li>
+                    <li>Cut per-build pipeline time by 25%+ by restructuring Jenkins around multi-stage Docker builds, parallelized image pushes, and layer caching.</li>
                 </ul>
 
                 <h6 class="text-primary">Software Engineer, SRE | Intelerad | Apr 2019 - Jan 2021 | Montreal, QC</h6>
                 <ul>
-                    <li>Joined when the platform was entirely on-premises with no automation. Built a CI/CD pipeline foundation on Jenkins with Docker from scratch, enabling automated releases worldwide for the first time.</li>
-                    <li>Built a secrets management infrastructure from scratch with Terraform, enabling product teams to secure APIs with short-lived JWT tokens and eliminating ad-hoc credential sharing across the organization.</li>
-                    <li>Cut per-build pipeline time 25%+ by restructuring Jenkins with multi-stage Docker builds, parallelized image pushes, and layer caching, compressing the feedback loop for every code change shipped.</li>
+                    <li>Established the CI/CD pipelines that let software releases reach healthcare clients worldwide, building the SRE foundation the team still runs on today.</li>
+                    <li>Designed and built the HashiCorp Vault platform from scratch with Terraform modules for dynamic DB credentials, transit encryption, and AWS auth, validated against a live cluster with a Go integration test suite.</li>
+                    <li>Owned the OS-level compatibility work for the CentOS 7 to RHEL 8 migration across package management, SSH key generation, and Ansible automation.</li>
                 </ul>
             </div>
             <div class="row mb-4 mx-auto">
                 <h6 class="text-primary">Software Developer (Consultant) | Morgan Stanley | Jan 2017 - Jan 2019 | Toronto, ON</h6>
                 <ul>
-                    <li>Joined Morgan Stanley's newly formed OTC Derivatives reporting team and built a regulatory data platform from the ground up before established tooling or process existed.</li>
-                    <li>Designed a low-latency data distribution system processing millions of transactions daily with sub-second SLAs, reducing trade reconciliation from 5 days to under 1 hour with a 90% accuracy improvement.</li>
+                    <li>Designed and built a low-latency data distribution system for Morgan Stanley's newly formed OTC Derivatives reporting team, covering Interest Rates, Credit, FX, and Options at millions of transactions a day with sub-second SLAs.</li>
+                    <li>Built an automated trade reconciliation system that cut reconciliation time from 5 days to under 1 hour, with 90% better accuracy than the manual process it replaced.</li>
                 </ul>
             </div>
         </div>


### PR DESCRIPTION
Updates the live cloud resume HTML with the polished 2026 content: new Staff title, rewritten summary, tightened bullets, removed expired AWS cert section, dropped 10+-year-old Sanofi internship.